### PR TITLE
Fix 404 error during prerender with special characters

### DIFF
--- a/app/routes/sitemap.ts
+++ b/app/routes/sitemap.ts
@@ -85,7 +85,7 @@ export async function loader({ request }: Route.LoaderArgs) {
         const articleLastMod = getValidTimestamp(publishedAt, lastModified);
 
         urls.push({
-          url: `${origin}/${user.nip05}/${identifier}`,
+          url: `${origin}/${user.nip05}/${encodeURIComponent(identifier)}`,
           lastmod: articleLastMod,
           changefreq: "monthly",
           priority: "0.9",

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -3,6 +3,17 @@ import type { Config } from "@react-router/dev/config";
 import { getMembers, getArticles } from "./app/services/data.server";
 import { getTagValue } from "applesauce-core/helpers";
 
+// Validate identifier for URL safety
+function isValidIdentifier(identifier: string | undefined): identifier is string {
+  if (!identifier || typeof identifier !== "string") return false;
+  // Check for reasonable length and no control characters
+  return (
+    identifier.length > 0 &&
+    identifier.length < 500 &&
+    !/[\x00-\x1F\x7F]/.test(identifier)
+  );
+}
+
 export default {
   ssr: true,
   presets: [vercelPreset()],
@@ -13,7 +24,9 @@ export default {
       result.push(`${user.nip05}`);
       const articles = await getArticles(user);
       for (const article of articles) {
-        result.push(`/${user.nip05}/${getTagValue(article, "d")}`);
+        const identifier = getTagValue(article, "d");
+        if (!isValidIdentifier(identifier)) continue;
+        result.push(`/${user.nip05}/${encodeURIComponent(identifier)}`);
       }
     }
     return result;


### PR DESCRIPTION
Article identifiers containing special characters like parentheses and non-ASCII characters (e.g., "köttbullar") were causing 404 errors during prerendering because they weren't being URL-encoded.

- Add encodeURIComponent() to prerender URL generation
- Add encodeURIComponent() to sitemap URL generation
- Add isValidIdentifier() validation to filter articles with control chars