### PR TITLE
Use inbox relays instead of general relays for zap queries

### DIFF
--- a/app/ui/nostr/article-conversation.tsx
+++ b/app/ui/nostr/article-conversation.tsx
@@ -5,7 +5,7 @@ import Highlight from "./highlight";
 import NostrCard from "./card";
 import {
   parseZap,
-  useRelays,
+  useInboxRelays,
   useTimeline,
   useZaps,
   type Zap,
@@ -210,6 +210,6 @@ export default function EventConversation({
 }
 
 export function Conversation({ event }: { event: NostrEvent }) {
-  const relays = useRelays(event.pubkey);
+  const relays = useInboxRelays(event.pubkey);
   return <EventConversation event={event} relays={relays} />;
 }

--- a/app/ui/nostr/reply.tsx
+++ b/app/ui/nostr/reply.tsx
@@ -8,7 +8,7 @@ import { CurrencyAmount } from "../currency";
 import UserLink from "./user-link";
 import RichText from "./rich-text";
 import { isReplaceableKind } from "nostr-tools/kinds";
-import { useProfile, useRelays, useTimeline } from "~/hooks/nostr";
+import { useProfile, useInboxRelays, useTimeline } from "~/hooks/nostr";
 import { useEventStore, useObservableMemo } from "applesauce-react/hooks";
 import {
   getSeenRelays,
@@ -219,7 +219,7 @@ function Repliers({ replies }: { replies: NostrEvent[] }) {
 }
 
 function Replies({ author, event }: { author: Pubkey; event?: NostrEvent }) {
-  const relays = useRelays(event?.pubkey || author);
+  const relays = useInboxRelays(event?.pubkey || author);
   const tagFilter =
     event && isReplaceableKind(event.kind)
       ? {


### PR DESCRIPTION
## Summary
This PR updates the application to use inbox relays (NIP-65) instead of general relay lists when querying for zaps. This improves zap discovery by targeting the relays where users explicitly receive zaps, rather than their general relay preferences.

## Key Changes
- Added `getInboxes` import from applesauce-core helpers
- Created new `useInboxRelays()` hook that retrieves inbox relays from a user's relay list event (kind 10002)
- Updated zap-related functions to use `useInboxRelays()` instead of `useRelays()`:
  - `usePubkeyZaps()`
  - `useZaps()`
  - `useProfileZaps()`
- Updated UI components to use the new hook:
  - `article-conversation.tsx`
  - `reply.tsx`

## Implementation Details
The new `useInboxRelays()` hook follows the same pattern as the existing `useRelays()` hook:
- Uses `eventStore.replaceable()` to fetch the relay list event
- Maps the event through `getInboxes()` to extract inbox relay URLs
- Triggers profile loading to ensure the relay list is available
- Returns an empty array if no event is found

This change aligns with NIP-65 best practices for zap relay discovery.

https://claude.ai/code/session_019cyGvKoW9wpPSKgAf1SdhW