### PR TITLE
Fix Blossom upload CORS issue by skipping HEAD pre-check

### DIFF
--- a/app/ui/editor.tsx
+++ b/app/ui/editor.tsx
@@ -724,23 +724,13 @@ export default () => {
   function handleImageUpload(url: string) {
     if (!editor) return;
 
-    // Insert image after the current block node.
-    // Using setImage() alone can place the image before the title heading
-    // when the cursor is inside it, since block images can't be nested in headings.
+    // Insert Blossom URL directly
     editor
       .chain()
       .focus()
-      .command(({ tr, state }) => {
-        const { $from } = state.selection;
-        // Find the end of the current top-level block
-        const endOfBlock = $from.end($from.depth === 0 ? 1 : $from.depth);
-        const insertPos = Math.min(endOfBlock + 1, state.doc.content.size);
-        const imageNode = state.schema.nodes.image.create({
-          src: url,
-          alt: "",
-        });
-        tr.insert(insertPos, imageNode);
-        return true;
+      .setImage({
+        src: url,
+        alt: "",
       })
       .run();
   }

--- a/app/ui/editor.tsx
+++ b/app/ui/editor.tsx
@@ -724,13 +724,23 @@ export default () => {
   function handleImageUpload(url: string) {
     if (!editor) return;
 
-    // Insert Blossom URL directly
+    // Insert image after the current block node.
+    // Using setImage() alone can place the image before the title heading
+    // when the cursor is inside it, since block images can't be nested in headings.
     editor
       .chain()
       .focus()
-      .setImage({
-        src: url,
-        alt: "",
+      .command(({ tr, state }) => {
+        const { $from } = state.selection;
+        // Find the end of the current top-level block
+        const endOfBlock = $from.end($from.depth === 0 ? 1 : $from.depth);
+        const insertPos = Math.min(endOfBlock + 1, state.doc.content.size);
+        const imageNode = state.schema.nodes.image.create({
+          src: url,
+          alt: "",
+        });
+        tr.insert(insertPos, imageNode);
+        return true;
       })
       .run();
   }


### PR DESCRIPTION
## Summary
Implement a custom `uploadBlob` function that bypasses the BUD-06 HEAD pre-check to avoid CORS errors on servers that don't include HEAD in their `Access-Control-Allow-Methods`.

## Key Changes
- Removed dependency on `Actions.uploadBlob` from blossom-client-sdk
- Added custom `uploadBlob` implementation that:
  - Skips the HEAD request entirely
  - Goes directly to PUT with authorization header
  - Uses `encodeAuthorizationHeader` to properly format auth
- Updated imports to include `encodeAuthorizationHeader` and type imports (`BlobDescriptor`, `SignedEvent`)
- Simplified auth callback in `uploadToBlossomServers` to pass only the sha256 hash
- Fixed auth type to always use `"upload"` instead of dynamic `authType` parameter

## Implementation Details
The custom `uploadBlob` function:
- Calculates file hash upfront
- Creates auth event via `createUploadAuth`
- Sends PUT request directly with `Authorization` header
- Handles errors by reading `x-reason` header or falling back to `statusText`
- Returns parsed JSON response as `BlobDescriptor`

This resolves CORS issues with servers like blossom.primal.net that don't support HEAD requests in their CORS configuration.

https://claude.ai/code/session_01BYbUieJyEyp1WEpmFM5Jmf